### PR TITLE
Fix lintr by bumping minimum R version to 4.1.0 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,6 @@ Imports:
     tibble,
     tidyr
 Depends: 
-    R (>= 2.10)
+    R (>= 4.1.0)
 LazyData: true
 LazyDataCompression: xz


### PR DESCRIPTION
This pull request increases the minimum version of R required to use the {climateR0} package to 4.1.0, from 2.10. 

I assume the dependency on R version 2.10 was automatically added to the package when you were adding other things, such as data with `usethis::use_data()`. I believe the `.lintr` file didn't like the 2.10 version, maybe because it expects versions to have three components (i.e. major.minor.patch) whereas 2.10 has just two.

I've chosen 4.1.0 as the base R pipe (`|>`) is used in the package which was added to R in 4.1.0, so ensuring user have 4.1.0 installed should ensure that the code works as expected.